### PR TITLE
Fix typo in include name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 #include  <signal.h>
 
 #include "constants.h"
-#include "CIoTrace.h"
+#include "CIOTrace.h"
 
 using namespace std;
 


### PR DESCRIPTION
Doesn't compile on case sensitive file system. This fixes it.