### PR TITLE
Makefile: -std=c++14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX      := -c++
-CXXFLAGS := -pedantic-errors -Wall -Wextra -Werror
+CXXFLAGS := -pedantic-errors -Wall -Wextra -Werror -std=c++14
 LDFLAGS  := -L/usr/lib -lstdc++ -lm
 BUILD    := ./build
 OBJ_DIR  := $(BUILD)/objects


### PR DESCRIPTION
For those running an older c++ compiler (e.g. gcc version 5.2.1), -std=c++14 needs to be specified to support c++14 features like std::make_unique

This change should have no negative impact when used with a modern compiler where c++14 or later is the default.